### PR TITLE
workaround for the split("/") in 'node-riffraff-artefact' 

### DIFF
--- a/build-tc
+++ b/build-tc
@@ -42,4 +42,6 @@ yarn bundle
 
 # push to riffraff
 
+export TEAMCITY_BRANCH="PR #${TEAMCITY_BRANCH/\// }" # workaround for .split("/").slice(-1)[0] in 'node-riffraff-artefact'
+
 yarn riffraff

--- a/build-tc
+++ b/build-tc
@@ -42,6 +42,6 @@ yarn bundle
 
 # push to riffraff
 
-export TEAMCITY_BRANCH="PR #${TEAMCITY_BRANCH/\// }" # workaround for .split("/").slice(-1)[0] in 'node-riffraff-artefact'
+export TEAMCITY_BRANCH=${TEAMCITY_BRANCH/\/merge/PR merge} # workaround for .split("/").slice(-1)[0] in 'node-riffraff-artefact'
 
 yarn riffraff


### PR DESCRIPTION
re-export TEAMCITY_BRANCH which removes / before 'node-riffraff-artefact' can split on / and conflate PRs into 'merge'
see https://github.com/guardian/node-riffraff-artefact/issues/30 for more info