### PR TITLE
set publicpath for webpack

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
     "bundle-dev-server": "webpack --config webpack.dev.server.js",
     "bundle-dev-client": "webpack --config webpack.dev.client.js",
     "serve-dev": "webpack-dev-server --config ./webpack.dev.client.js --public account.thegulocal.com",
-    "watch": "yarn bundle-dev-server && (yarn start & yarn serve-dev & yarn bundle-dev-server -w)",
+    "watch": "yarn bundle-dev-server && (yarn bundle-dev-server -w & yarn start & yarn serve-dev)",
     "test": "yarn lint && yarn type-check && jest --coverage",
     "fix": "pretty-quick && tslint --fix -p .",
     "precommit": "pretty-quick --staged && tslint --fix -p .",

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -71,7 +71,8 @@ const client = merge(common, {
   output: {
     path: path.resolve(__dirname, "dist", "static"),
     filename: "[name].js",
-    chunkFilename: "[name].js"
+    chunkFilename: "[name].js",
+    publicPath: "/static/"
   },
   module: {
     rules: [


### PR DESCRIPTION
Restores the publicPath property so webpack dev server doesn't proxy the client bundle. I thought that it was working without this, but I must have been mistaken. @twrichards 
