### PR TITLE
Make riffraff update amis

### DIFF
--- a/cloud-formation/account-frontend-cf.yaml
+++ b/cloud-formation/account-frontend-cf.yaml
@@ -29,7 +29,7 @@ Parameters:
   AMI:
     Description: AMI ID
     Type: String
-    Default: ami-5a747db0
+    Default: ami-88a6af62
   OfficeCIDR:
     Description: Office IP range
     Type: String

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,12 +10,13 @@ deployments:
       templatePath: cloudformation/account-frontend-cf.yaml
   account-frontend:
     type: autoscaling
-    dependencies: [account-frontend-cloudformation]
+    dependencies: [account-frontend-cloudformation, account-frontend-ami]
     parameters:
       bucket: membership-dist
   account-frontend-ami:
     app: account-frontend
     type: ami-cloudformation-parameter
+    dependencies: [account-frontend-cloudformation]
     parameters:
       amiTags:
         Recipe: xenial-membership


### PR DESCRIPTION
Applies the cloudformation template updates before updating the ami parameter. 
This might also be soluble by removing the default ami parameter.