### PR TITLE
added "Cache-Control: private" header to every response to prevent Fastly issues

### DIFF
--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -31,6 +31,13 @@ if (conf.ENVIRONMENT === Environments.PRODUCTION && !conf.CLIENT_DSN) {
 }
 const globals: Globals = { domain: conf.DOMAIN };
 
+server.use(
+  (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    res.header("Cache-Control", "private");
+    next();
+  }
+);
+
 server.use(helmet());
 
 server.get("/_healthcheck", (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
since api requests are proxied via Node, Fastly was caching api endpoint responses and thus serving up users data to other users 😱 